### PR TITLE
Add guide to the signature of reduceOT. Handle the edge case that empty OT becomes NULL after merge.

### DIFF
--- a/R/breakinspector.R
+++ b/R/breakinspector.R
@@ -421,6 +421,7 @@ read_targets <- function(x, genome, standard_chromosomes, strandless) {
 #'
 #' @param x A GRanges object containing the results of a breakinspectoR
 #' analysis.
+#' @param guide character vector with the guide RNA sequence.
 #' @param fdr numerical, keep only hits below this empirical FDR threshold.
 #' @param qval numerical, keep only hits below this q-value threshold.
 #' @param mismatches numeric, mismatches allowed between the guide and the
@@ -453,9 +454,9 @@ read_targets <- function(x, genome, standard_chromosomes, strandless) {
 #' }
 #' data(breakinspectoR_examples)
 #'
-#' offtargets_filtered <- reduceOT(offtargets)
+#' offtargets_filtered <- reduceOT(offtargets, guide)
 #'
-reduceOT <- function(x, fdr=.01, qval=.01, mismatches=7, standard_chromosomes=TRUE,
+reduceOT <- function(x, guide, fdr=.01, qval=.01, mismatches=7, standard_chromosomes=TRUE,
                    cores=getOption("mc.cores", 2L),
                    verbose=TRUE) {
 
@@ -476,6 +477,11 @@ reduceOT <- function(x, fdr=.01, qval=.01, mismatches=7, standard_chromosomes=TR
        x[x$mismatches <= mismatches]
     }, error=function(e) x)
   msg(verbose, " done", appendLF=TRUE)
+
+  # return if GRanges object is empty
+  if (length(x) == 0) {
+    return(x)
+  }
 
   # merge different OT in same protospacer
   msg(verbose, "Merging different OT in same protospacer...", appendLF=FALSE)


### PR DESCRIPTION
The `reduceOT` has no input for guide in its function signature. It uses the guide from the parent frame. This is error-prone. I suggest add guide to the function signature.

`reduceOT` raise error when no OT left after filtering out by FDR, q-value and mismatch. This is because https://github.com/roukoslab/breakinspectoR/blob/c27574244d2eee2bd79a41a817b91636253734af/R/breakinspector.R#L485-L488 returns `NULL`, which breaks https://github.com/roukoslab/breakinspectoR/blob/c27574244d2eee2bd79a41a817b91636253734af/R/breakinspector.R#L510.
